### PR TITLE
allow access to check key expiration

### DIFF
--- a/lib/resque/resque.rb
+++ b/lib/resque/resque.rb
@@ -14,6 +14,10 @@ module Resque
   alias_method :enqueue_without_throttle, :enqueue
   alias_method :enqueue, :enqueue_with_throttle
 
+  def has_key?(klass, *args)
+    return key_found?(klass, *args)
+  end
+
   private
    
   def should_throttle?(klass, *args)


### PR DESCRIPTION
Can check the expiration of key from outside.

This is not quite necessary for general usage (I'm using this for specific reason), so you may ignore it. 
